### PR TITLE
GameCQ content fully visible, and page is relative.

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -258,13 +258,15 @@ button.ghost {
 html, body {
   height: 100%;
   margin: 0;
-  overflow: hidden; /* Prevents scrolling, ensuring video fills the viewport */
+  /* overflow: hidden;  */
+  /* Prevents scrolling, ensuring video fills the viewport */
 }
 
 .game-container {
   position: relative;
-  height: 100vh; /* Ensures the container fills the viewport height */
-  color: var(black));
+  /* height: 100vh;  */
+  /* Ensures the container fills the viewport height */
+  color: black;
   font-family: 'Orbitron', sans-serif;
   text-align: center;
   padding: 20px;


### PR DESCRIPTION
GameCQ content fully visible, and page is relative.

Disabled overflow hidden - to allow scrolling
Disabled .game-container height: 100vh;  - to allow the full content to show on page.
Added position: relative; - to allow relativity, so page can be viewed on all devices.
